### PR TITLE
Excluding manually installed Plugins. fixes #2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 /[Uu]ser[Ss]ettings/
 /[Uu][Ii][Ee]lements[Ss]chema/
 
+# Asset meta data should only be ignored when the corresponding asset is also ignored
+!/[Aa]ssets/**/*.meta
+
 # Exclude Plugin Reachy-Assets (making version-change easier)
 /[Aa]ssets/[Rr]eachy[Ss]imulator/
 /[Aa]ssets/[Rr]eachy[Ss]imulator.meta
@@ -19,9 +22,6 @@
 # Exclude Plugin the grpc-plugin (Excessive in size would bloat up this project)
 /[Aa]ssets/[Pp]lugins/
 /[Aa]ssets/[Pp]lugins.meta
-
-# Asset meta data should only be ignored when the corresponding asset is also ignored
-!/[Aa]ssets/**/*.meta
 
 # Uncomment this line if you wish to ignore the asset store tools plugin
 # /[Aa]ssets/AssetStoreTools*


### PR DESCRIPTION
There may be potential issues as the prefabs Reachy and Server need to be used in the Unity scenes. As a suggestion, in this scenario, you can modify the .gitignore file again to include the Reachy Unity package or perhaps just the .meta files.