### PR TITLE
Recommendation to avoid conflicts when merging branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 /[Uu]ser[Ss]ettings/
 /[Uu][Ii][Ee]lements[Ss]chema/
 
+# Asset meta data should only be ignored when the corresponding asset is also ignored
+!/[Aa]ssets/**/*.meta
+
 # Exclude Plugin Reachy-Assets (making version-change easier)
 /[Aa]ssets/[Rr]eachy[Ss]imulator/
 /[Aa]ssets/[Rr]eachy[Ss]imulator.meta
@@ -19,9 +22,6 @@
 # Exclude Plugin the grpc-plugin (Excessive in size would bloat up this project)
 /[Aa]ssets/[Pp]lugins/
 /[Aa]ssets/[Pp]lugins.meta
-
-# Asset meta data should only be ignored when the corresponding asset is also ignored
-!/[Aa]ssets/**/*.meta
 
 # Uncomment this line if you wish to ignore the asset store tools plugin
 # /[Aa]ssets/AssetStoreTools*


### PR DESCRIPTION
The last pull request #3 utilized squash merging. However, since the dev branch must not be deleted, it is recommended to redo the merge using the default merge method to prevent any potential conflicts in the future.